### PR TITLE
Support new iOS spec

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{package.json,*.yml}]
+[*.yml]
 indent_style = space
 indent_size = 2

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install graphicsmagick
 node_js:
+  - '10'
+  - '8'
   - '6'
-  - '4'

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = (file, opts) => {
 
 	return pify(img.identify.bind(img))()
 		.then(identity => {
-			const size = identity.size;
+			const {size} = identity;
 
 			return Promise.all(screens.map(screen => {
 				const dest = path.join(opts.dest, screen.name);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,6 +12,7 @@ const fsP = pify(fs);
  * @param {number}	imgSize			Size of the source image.
  * @param {number}	screenSize		Size of the destination image.
  * @param {Object}	opts			Options object.
+ * @returns {Object} result			Object with px an size object
  */
 exports.calculateDimension = (imgSize, screenSize, opts) => {
 	let width;
@@ -44,6 +45,7 @@ exports.calculateDimension = (imgSize, screenSize, opts) => {
  * @param {string}	file		Source file.
  * @param {Object}	screen		Screen dimension.
  * @param {Object} 	dimension	Content dimension.
+ * @returns {Promise} result 	Promise which resolves with images with the nine-patch borders.
  */
 exports.draw9Patch = (file, screen, dimension) => {
 	// To draw the 9patches, we only need the pixels

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,6 @@ const fsP = pify(fs);
  * @param {number}	imgSize			Size of the source image.
  * @param {number}	screenSize		Size of the destination image.
  * @param {Object}	opts			Options object.
- * @returns {Object} result			Object with px an size object
  */
 exports.calculateDimension = (imgSize, screenSize, opts) => {
 	let width;
@@ -45,7 +44,6 @@ exports.calculateDimension = (imgSize, screenSize, opts) => {
  * @param {string}	file		Source file.
  * @param {Object}	screen		Screen dimension.
  * @param {Object} 	dimension	Content dimension.
- * @returns {Promise} result 	Promise which resolves with images with the nine-patch borders.
  */
 exports.draw9Patch = (file, screen, dimension) => {
 	// To draw the 9patches, we only need the pixels

--- a/package.json
+++ b/package.json
@@ -1,50 +1,50 @@
 {
-  "name": "mobisplash",
-  "version": "0.2.1",
-  "description": "Mobile app splash screen generator",
-  "license": "MIT",
-  "repository": "SamVerschueren/mobisplash",
-  "author": {
-    "name": "Sam Verschueren",
-    "email": "sam.verschueren@gmail.com",
-    "url": "github.com/SamVerschueren"
-  },
-  "engines": {
-    "node": ">=4"
-  },
-  "scripts": {
-    "test": "xo && ava"
-  },
-  "files": [
-    "index.js",
-    "platforms.json",
-    "lib"
-  ],
-  "keywords": [
-    "mobile",
-    "app",
-    "application",
-    "splash",
-    "screen",
-    "splashscreen",
-    "generator",
-    "mobisplash",
-    "cordova",
-    "android",
-    "ios",
-    "blackberry10",
-    "ninepatch",
-    "9patch"
-  ],
-  "dependencies": {
-    "gm": "^1.21.1",
-    "mkdirp": "^0.5.1",
-    "pify": "^2.3.0"
-  },
-  "devDependencies": {
-    "ava": "*",
-    "path-exists": "^3.0.0",
-    "tempfile": "^1.1.1",
-    "xo": "*"
-  }
+	"name": "mobisplash",
+	"version": "0.2.1",
+	"description": "Mobile app splash screen generator",
+	"license": "MIT",
+	"repository": "SamVerschueren/mobisplash",
+	"author": {
+		"name": "Sam Verschueren",
+		"email": "sam.verschueren@gmail.com",
+		"url": "github.com/SamVerschueren"
+	},
+	"engines": {
+		"node": ">=6"
+	},
+	"scripts": {
+		"test": "xo && ava"
+	},
+	"files": [
+		"index.js",
+		"platforms.json",
+		"lib"
+	],
+	"keywords": [
+		"mobile",
+		"app",
+		"application",
+		"splash",
+		"screen",
+		"splashscreen",
+		"generator",
+		"mobisplash",
+		"cordova",
+		"android",
+		"ios",
+		"blackberry10",
+		"ninepatch",
+		"9patch"
+	],
+	"dependencies": {
+		"gm": "^1.21.1",
+		"mkdirp": "^0.5.1",
+		"pify": "^2.3.0"
+	},
+	"devDependencies": {
+		"ava": "*",
+		"path-exists": "^3.0.0",
+		"tempfile": "^1.1.1",
+		"xo": "*"
+	}
 }

--- a/platforms.json
+++ b/platforms.json
@@ -1,162 +1,162 @@
 {
-  "android": {
-    "portrait": [
-      {
-        "name": "drawable-ldpi-port/splash.png",
-        "width": 200,
-        "height": 320
-      },
-      {
-        "name": "drawable-mdpi-port/splash.png",
-        "width": 320,
-        "height": 480
-      },
-      {
-        "name": "drawable-hdpi-port/splash.png",
-        "width": 480,
-        "height": 800
-      },
-      {
-        "name": "drawable-xhdpi-port/splash.png",
-        "width": 720,
-        "height": 1280
-      },
-      {
-        "name": "drawable-xxhdpi-port/splash.png",
-        "width": 960,
-        "height": 1600
-      },
-      {
-        "name": "drawable-xxxhdpi-port/splash.png",
-        "width": 1280,
-        "height": 1920
-      }
-    ],
-    "landscape": [
-      {
-        "name": "drawable-ldpi-land/splash.png",
-        "width": 320,
-        "height": 200
-      },
-      {
-        "name": "drawable-mdpi-land/splash.png",
-        "width": 480,
-        "height": 320
-      },
-      {
-        "name": "drawable-hdpi-land/splash.png",
-        "width": 800,
-        "height": 480
-      },
-      {
-        "name": "drawable-xhdpi-land/splash.png",
-        "width": 1280,
-        "height": 720
-      },
-      {
-        "name": "drawable-xxhdpi-land/splash.png",
-        "width": 1600,
-        "height": 960
-      },
-      {
-        "name": "drawable-xxxhdpi-land/splash.png",
-        "width": 1920,
-        "height": 1280
-      }
-    ]
-  },
-  "ios": {
-    "portrait": [
-      {
-        "name": "Default~iphone.png",
-        "width": 320,
-        "height": 480
-      },
-      {
-        "name": "Default@2x~iphone.png",
-        "width": 640,
-        "height": 960
-      },
-      {
-        "name": "Default-Portrait~ipad.png",
-        "width": 768,
-        "height": 1024
-      },
-      {
-        "name": "Default-Portrait@2x~ipad.png",
-        "width": 1536,
-        "height": 2048
-      },
-      {
-        "name": "Default-568h@2x~iphone.png",
-        "width": 640,
-        "height": 1136
-      },
-      {
-        "name": "Default-667h.png",
-        "width": 750,
-        "height": 1334
-      },
-      {
-        "name": "Default-736h.png",
-        "width": 1242,
-        "height": 2208
-      }
-    ],
-    "landscape": [
-      {
-        "name": "Default-Landscape~ipad.png",
-        "width": 1024,
-        "height": 768
-      },
-      {
-        "name": "Default-Landscape@2x~ipad.png",
-        "width": 2048,
-        "height": 1536
-      },
-      {
-        "name": "Default-Landscape-736h.png",
-        "width": 2208,
-        "height": 1242
-      }
-    ]
-  },
-  "blackberry10": {
-    "square": [
-      {
-        "name": "splash-720x720.png",
-        "width": 720,
-        "height": 720
-      },
-      {
-        "name": "splash-1440x1440.png",
-        "width": 1440,
-        "height": 1440
-      }
-    ],
-    "portrait": [
-      {
-        "name": "splash-768x1280.png",
-        "width": 768,
-        "height": 1280
-      },
-      {
-        "name": "splash-720x1280.png",
-        "width": 720,
-        "height": 1280
-      }
-    ],
-    "landscape": [
-      {
-        "name": "splash-1280x768.png",
-        "width": 1280,
-        "height": 768
-      },
-      {
-        "name": "splash-1280x720.png",
-        "width": 1280,
-        "height": 720
-      }
-    ]
-  }
+	"android": {
+		"portrait": [
+			{
+				"name": "drawable-ldpi-port/splash.png",
+				"width": 200,
+				"height": 320
+			},
+			{
+				"name": "drawable-mdpi-port/splash.png",
+				"width": 320,
+				"height": 480
+			},
+			{
+				"name": "drawable-hdpi-port/splash.png",
+				"width": 480,
+				"height": 800
+			},
+			{
+				"name": "drawable-xhdpi-port/splash.png",
+				"width": 720,
+				"height": 1280
+			},
+			{
+				"name": "drawable-xxhdpi-port/splash.png",
+				"width": 960,
+				"height": 1600
+			},
+			{
+				"name": "drawable-xxxhdpi-port/splash.png",
+				"width": 1280,
+				"height": 1920
+			}
+		],
+		"landscape": [
+			{
+				"name": "drawable-ldpi-land/splash.png",
+				"width": 320,
+				"height": 200
+			},
+			{
+				"name": "drawable-mdpi-land/splash.png",
+				"width": 480,
+				"height": 320
+			},
+			{
+				"name": "drawable-hdpi-land/splash.png",
+				"width": 800,
+				"height": 480
+			},
+			{
+				"name": "drawable-xhdpi-land/splash.png",
+				"width": 1280,
+				"height": 720
+			},
+			{
+				"name": "drawable-xxhdpi-land/splash.png",
+				"width": 1600,
+				"height": 960
+			},
+			{
+				"name": "drawable-xxxhdpi-land/splash.png",
+				"width": 1920,
+				"height": 1280
+			}
+		]
+	},
+	"ios": {
+		"portrait": [
+			{
+				"name": "Default~iphone.png",
+				"width": 320,
+				"height": 480
+			},
+			{
+				"name": "Default@2x~iphone.png",
+				"width": 640,
+				"height": 960
+			},
+			{
+				"name": "Default-Portrait~ipad.png",
+				"width": 768,
+				"height": 1024
+			},
+			{
+				"name": "Default-Portrait@2x~ipad.png",
+				"width": 1536,
+				"height": 2048
+			},
+			{
+				"name": "Default-568h@2x~iphone.png",
+				"width": 640,
+				"height": 1136
+			},
+			{
+				"name": "Default-667h.png",
+				"width": 750,
+				"height": 1334
+			},
+			{
+				"name": "Default-736h.png",
+				"width": 1242,
+				"height": 2208
+			}
+		],
+		"landscape": [
+			{
+				"name": "Default-Landscape~ipad.png",
+				"width": 1024,
+				"height": 768
+			},
+			{
+				"name": "Default-Landscape@2x~ipad.png",
+				"width": 2048,
+				"height": 1536
+			},
+			{
+				"name": "Default-Landscape-736h.png",
+				"width": 2208,
+				"height": 1242
+			}
+		]
+	},
+	"blackberry10": {
+		"square": [
+			{
+				"name": "splash-720x720.png",
+				"width": 720,
+				"height": 720
+			},
+			{
+				"name": "splash-1440x1440.png",
+				"width": 1440,
+				"height": 1440
+			}
+		],
+		"portrait": [
+			{
+				"name": "splash-768x1280.png",
+				"width": 768,
+				"height": 1280
+			},
+			{
+				"name": "splash-720x1280.png",
+				"width": 720,
+				"height": 1280
+			}
+		],
+		"landscape": [
+			{
+				"name": "splash-1280x768.png",
+				"width": 1280,
+				"height": 768
+			},
+			{
+				"name": "splash-1280x720.png",
+				"width": 1280,
+				"height": 720
+			}
+		]
+	}
 }

--- a/platforms.json
+++ b/platforms.json
@@ -66,6 +66,59 @@
 		]
 	},
 	"ios": {
+		"square": [
+			{
+				"name": "Default@2x~iphone~anyany.png",
+				"width": 1334,
+				"height": 1334
+			},
+			{
+				"name": "Default@3x~iphone~anyany.png",
+				"width": 2208,
+				"height": 2208
+			},
+			{
+				"name": "Default@2x~ipad~anyany.png",
+				"width": 2732,
+				"height": 2732
+			},
+			{
+				"name": "Default@2x~universal~anyany.png",
+				"width": 2732,
+				"height": 2732
+			}
+		],
+		"portarit": [
+			{
+				"name": "Default@2x~iphone~comany.png",
+				"width": 750,
+				"height": 1334
+			},
+			{
+				"name": "Default@3x~iphone~comany.png",
+				"width": 1242,
+				"height": 2208
+			},
+			{
+				"name": "Default@2x~ipad~comany.png",
+				"width": 1278,
+				"height": 2732
+			}
+		],
+		"landscape": [
+			{
+				"name": "Default@2x~iphone~comcom.png",
+				"width": 1334,
+				"height": 750
+			},
+			{
+				"name": "Default@3x~iphone~comany.png",
+				"width": 2208,
+				"height": 1242
+			}
+		]
+	},
+	"ios-legacy": {
 		"portrait": [
 			{
 				"name": "Default~iphone.png",

--- a/platforms.json
+++ b/platforms.json
@@ -88,7 +88,7 @@
 				"height": 2732
 			}
 		],
-		"portarit": [
+		"portrait": [
 			{
 				"name": "Default@2x~iphone~comany.png",
 				"width": 750,

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import test from 'ava';
 import tempfile from 'tempfile';
-import fn from '../';
+import m from '..';
 import {exists, notExists, isLandscape, isPortrait, isSquare, size} from './fixtures/utils';
 
 test.beforeEach(t => {
@@ -27,7 +27,7 @@ test('android', async t => {
 		'drawable-xxxhdpi-port/splash.png'
 	];
 
-	await fn('test/fixtures/icon.png', {platform: 'android', dest: t.context.tmp, draw9patch: false});
+	await m('test/fixtures/icon.png', {platform: 'android', dest: t.context.tmp, draw9patch: false});
 
 	exists(t, [].concat(landscape, portrait));
 	await isLandscape(t, landscape);
@@ -51,7 +51,7 @@ test('ios', async t => {
 		'Default-Portrait@2x~ipad.png'
 	];
 
-	await fn('test/fixtures/icon.png', {platform: 'ios', dest: t.context.tmp});
+	await m('test/fixtures/icon.png', {platform: 'ios', dest: t.context.tmp});
 
 	exists(t, [].concat(landscape, portrait));
 	await isLandscape(t, landscape);
@@ -74,7 +74,7 @@ test('bb10', async t => {
 		'splash-1440x1440.png'
 	];
 
-	await fn('test/fixtures/icon.png', {platform: 'blackberry10', dest: t.context.tmp});
+	await m('test/fixtures/icon.png', {platform: 'blackberry10', dest: t.context.tmp});
 
 	exists(t, [].concat(landscape, portrait, square));
 	await isLandscape(t, landscape);
@@ -83,7 +83,7 @@ test('bb10', async t => {
 });
 
 test('portrait', async t => {
-	await fn('test/fixtures/icon.png', {platform: 'blackberry10', dest: t.context.tmp, orientation: 'portrait'});
+	await m('test/fixtures/icon.png', {platform: 'blackberry10', dest: t.context.tmp, orientation: 'portrait'});
 
 	exists(t, [
 		'splash-720x1280.png',
@@ -99,7 +99,7 @@ test('portrait', async t => {
 });
 
 test('9patch', async t => {
-	await fn('test/fixtures/icon.svg', {platform: 'android', dest: t.context.tmp, orientation: 'portrait'});
+	await m('test/fixtures/icon.svg', {platform: 'android', dest: t.context.tmp, orientation: 'portrait'});
 
 	exists(t, 'drawable-ldpi-port/splash.9.png');
 	notExists(t, 'drawable-ldpi-port/splash.png');
@@ -110,7 +110,7 @@ test('9patch', async t => {
 });
 
 test('no 9patch', async t => {
-	await fn('test/fixtures/icon.svg', {platform: 'android', dest: t.context.tmp, orientation: 'portrait', draw9patch: false});
+	await m('test/fixtures/icon.svg', {platform: 'android', dest: t.context.tmp, orientation: 'portrait', draw9patch: false});
 
 	notExists(t, 'drawable-ldpi-port/splash.9.png');
 	exists(t, 'drawable-ldpi-port/splash.png');


### PR DESCRIPTION
I've changed the old iOS screens to an `ios-legacy` property and replaces the `ios` property with the new iOS specifications for Splashscreens.

[Cordova spec](https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-splashscreen/index.html)
[Medium Post](https://blog.phonegap.com/displaying-a-phonegap-app-correctly-on-the-iphone-x-c4a85664c493)

I also fixed some linting issues, but the tests failed. Did not have time to look into the exact issue.